### PR TITLE
Adding SC21 details and package for citing multiple figures

### DIFF
--- a/report/cls/SCreport.cls
+++ b/report/cls/SCreport.cls
@@ -188,6 +188,12 @@
   \restoregeometry
 }
 
+% 5.5 Refer to multiple figures inline using autorefs
+%  -- Use \cref{l1,l1,etc.} To comma separate figures
+%  -- Or \Crefrange{l1}{l5} for a range separate with -- 
+\usepackage[nameinlink, capitalize]{cleveref}
+\Crefname{figure}{Figure}{Figures}
+
 % ------------
 % 6 Title page
 % ------------
@@ -254,6 +260,11 @@
   \IfStrEq{\typedef}{SC20}{\def\tplocation{Manila, Philippines}}{}
   \IfStrEq{\typedef}{SC20}{\def\tpdates{14--21 August 2024}}{}
   \IfStrEq{\typedef}{SC20}{\def\tpnum{WCPFC-SC20-2024}}{}
+  % SC21
+  \IfStrEq{\typedef}{SC20}{\def\tpmeeting{SCIENTIFIC COMMITTEE\\TWENTY FIRST REGULAR SESSION}}{}
+  \IfStrEq{\typedef}{SC20}{\def\tplocation{Nuku'alofa, Tonga}}{}
+  \IfStrEq{\typedef}{SC20}{\def\tpdates{13--21 August 2024}}{}
+  \IfStrEq{\typedef}{SC20}{\def\tpnum{WCPFC-SC21-2025}}{}
 }
 
 % 6.3 Render title page


### PR DESCRIPTION
I have found the cleveref package helpful for citing multiple figures using autoref, inline, but if there is a better way, please feel free to remove this.